### PR TITLE
Support Array Responses

### DIFF
--- a/brainstem-adaptor.gemspec
+++ b/brainstem-adaptor.gemspec
@@ -5,9 +5,9 @@ Gem::Specification.new do |s|
   s.version = "0.0.4"
 
   s.date = %q{2014-03-10}
-  s.authors = ["Sergei Zinin (einzige)"]
-  s.email = %q{szinin@gmail.com}
-  s.homepage = %q{http://github.com/einzige/brainstem-adaptor}
+  s.authors = ["Mavenlink", "Sergei Zinin (einzige)"]
+  s.email = ["opensource@mavenlink.com", "szinin@gmail.com"]
+  s.homepage = %q{https://github.com/mavenlink/brainstem-adaptor}
 
   s.licenses = ["MIT"]
 

--- a/brainstem-adaptor.gemspec
+++ b/brainstem-adaptor.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{brainstem-adaptor}
-  s.version = "0.0.3"
+  s.version = "0.0.4"
 
   s.date = %q{2014-03-10}
   s.authors = ["Sergei Zinin (einzige)"]

--- a/lib/brainstem-adaptor.rb
+++ b/lib/brainstem-adaptor.rb
@@ -7,6 +7,7 @@ require 'brainstem_adaptor/specification'
 require 'brainstem_adaptor/association'
 require 'brainstem_adaptor/record'
 require 'brainstem_adaptor/invalid_response_error'
+require 'brainstem_adaptor/parsers/array_parser'
 require 'brainstem_adaptor/response'
 
 module BrainstemAdaptor

--- a/lib/brainstem-adaptor.rb
+++ b/lib/brainstem-adaptor.rb
@@ -11,7 +11,7 @@ require 'brainstem_adaptor/parsers/array_parser'
 require 'brainstem_adaptor/response'
 
 module BrainstemAdaptor
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 
   def self.parser
     @parser ||= JSON

--- a/lib/brainstem_adaptor/parsers/array_parser.rb
+++ b/lib/brainstem_adaptor/parsers/array_parser.rb
@@ -1,0 +1,24 @@
+module BrainstemAdaptor
+  module Parsers
+    module ArrayParser
+      # Parse irregular endpoints that return an array of objects instead of the standard JSON response
+      def self.parse(response_data, collection_name)
+        raise InvalidResponseError, "collection name is not specified" unless collection_name
+
+        {
+          "count" => response_data.count,
+          "results" => response_data.map do |obj|
+            {
+              "key" => collection_name,
+              "id" => obj["id"].to_s
+            }
+          end,
+          collection_name => response_data.reduce({}) do |hash, obj|
+            hash[obj["id"].to_s] = obj
+            hash
+          end
+        }
+      end
+    end
+  end
+end

--- a/lib/brainstem_adaptor/response.rb
+++ b/lib/brainstem_adaptor/response.rb
@@ -4,7 +4,7 @@ module BrainstemAdaptor
 
     # @param response_data [String, Hash]
     # @param specification [BrainstemAdaptor::Specification]
-    def initialize(response_data, specification = BrainstemAdaptor.default_specification)
+    def initialize(response_data, specification = BrainstemAdaptor.default_specification, **options)
       @specification = specification or raise ArgumentError, 'Specification is not set'
 
       case response_data
@@ -12,6 +12,8 @@ module BrainstemAdaptor
         @response_data = BrainstemAdaptor.parser.parse(response_data)
       when Hash
         @response_data = response_data
+      when Array
+        @response_data = BrainstemAdaptor::Parsers::ArrayParser.parse(response_data, options[:collection_name])
       else
         raise ArgumentError, "Expected String, got #{@response_data.class.name}"
       end

--- a/spec/lib/brainstem_adaptor/parsers/array_parser_spec.rb
+++ b/spec/lib/brainstem_adaptor/parsers/array_parser_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+describe BrainstemAdaptor::Parsers::ArrayParser do
+  describe ".parse" do
+    subject { described_class.parse(response_data, collection_name) }
+
+    let(:response_data) do
+      [
+        {
+          "id" => "1",
+          "title" => "An object"
+        },
+        {
+          "id" => "2",
+          "title" => "A newer object"
+        }
+      ]
+    end
+
+    let(:collection_name) { "workspaces" }
+
+    let(:formatted_response) do
+      {
+        "count" => response_data.count,
+        "results" => [
+          {
+            "key" => collection_name,
+            "id" => response_data[0]["id"]
+          },
+          {
+            "key" => collection_name,
+            "id" => response_data[1]["id"]
+          }
+        ],
+        collection_name => {
+          response_data[0]["id"] => response_data[0],
+          response_data[1]["id"] => response_data[1]
+        }
+      }
+    end
+
+    it "formats the response to match brainstem" do
+      expect(subject).to eq formatted_response
+    end
+
+    context "when collection name is not given" do
+      let(:collection_name) { nil }
+
+      it "raises an InvalidResponseError" do
+        expect { subject }.to raise_error(BrainstemAdaptor::InvalidResponseError)
+      end
+    end
+  end
+end

--- a/spec/lib/brainstem_adaptor/response_spec.rb
+++ b/spec/lib/brainstem_adaptor/response_spec.rb
@@ -181,6 +181,17 @@ describe BrainstemAdaptor::Response do
     end
   end
 
+  context "when array input" do
+    subject { described_class.new(response_data, collection_name: collection_name) }
+    let(:response_data) { [{ "id" => "1" }] }
+    let(:collection_name) { "object" }
+
+    it "formats the response data using the array parser" do
+      expect(BrainstemAdaptor::Parsers::ArrayParser).to receive(:parse).with(response_data, collection_name).and_call_original
+      subject
+    end
+  end
+
   describe '#to_hash' do
     specify do
       expect(subject.to_hash).to eq(response_hash)


### PR DESCRIPTION
This PR adds in support for formatting array responses into the standard brainstem format of:
```
{
    "count": 1,
    "results": [
        {
            "key": "objects",
            "id": "1"
        }
    ],
    "objects": {
        "1": {
            ... attributes ...
        }
    }
}
```